### PR TITLE
Accessibility Suggestion

### DIFF
--- a/src/override.css
+++ b/src/override.css
@@ -60,7 +60,7 @@ menu {
 }
 
 input {
-	outline: none;
+	outline-color: transparent;
 	border: none;
 }
 


### PR DESCRIPTION
Small accessibility defect in CSS when using "outline: none" was fixed. Made simple changes following best practices to prevent users with higher contrasts from experiencing bugs when using the tab key to select buttons, inputs, etc. Reference: https://www.youtube.com/shorts/4B_4WLpbyp8